### PR TITLE
Support linux backspace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ fn keyboard(
                 }
 
                 for event in character_events.iter() {
-                    if event.char == '\u{7f}' {
+                    if ['\u{7f}', '\u{8}'].contains(&event.char) {
                         text.sections[0].value.pop();
                         continue;
                     }


### PR DESCRIPTION
Backspace just doesn't work for me. It places a `\u{8}` instead of removing the character behind the cursor. This fixes it.

`8` is the decimal and hexadecimal representation for the ASCII backspace (`\b`) so it makes sense that it would be what bevy receives as input when pressing backspace. `7f` is the delete ASCII character.