### PR TITLE
Add cursor timer reset on input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ const CURSOR_HANDLE: Handle<Font> = Handle::weak_from_u128(10482756907980398621)
 
 /// A bundle providing the additional components required for a text input.
 ///
-/// Add this to a `NodeBundle`.
+/// Add this to a [`NodeBundle`].
 ///
 /// Examples:
 /// ```rust
@@ -60,7 +60,7 @@ pub struct TextInputBundle {
 }
 
 impl TextInputBundle {
-    /// Creates a new `TextInputBundle` with the specified `TextStyle`.
+    /// Creates a new [`TextInputBundle`] with the specified [`TextStyle`].
     pub fn new(text_style: TextStyle) -> Self {
         Self {
             text_style: TextInputTextStyle(text_style),
@@ -68,7 +68,7 @@ impl TextInputBundle {
         }
     }
 
-    /// Creates a new `TextInputBundle` with the specified `TextStyle` and starting text.
+    /// Creates a new [`TextInputBundle`] with the specified [`TextStyle`] and starting text.
     pub fn with_starting_text(text_style: TextStyle, starting_text: String) -> Self {
         Self {
             text_style: TextInputTextStyle(text_style),
@@ -78,7 +78,7 @@ impl TextInputBundle {
     }
 }
 
-/// The `TextStyle` that will be used when creating the text input's inner `TextBundle`.
+/// The [`TextStyle`] that will be used when creating the text input's inner [`TextBundle`].
 #[derive(Component, Default)]
 pub struct TextInputTextStyle(pub TextStyle);
 
@@ -112,7 +112,7 @@ pub struct TextInputSubmitEvent {
     pub value: String,
 }
 
-/// A convenience parameter for dealing with a `TextInput`'s inner `Text` entity.
+/// A convenience parameter for dealing with a [`TextInput`]'s inner [`Text`] entity.
 #[derive(SystemParam)]
 struct InnerText<'w, 's> {
     text_query: Query<'w, 's, &'static mut Text, With<TextInputInner>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,29 +127,9 @@ impl<'w, 's> InnerText<'w, 's> {
     }
 }
 
-/// Used to set the visibility of the cursor based on the `active` parameter.
-#[macro_export]
-macro_rules! set_cursor {
-    ($active:expr, $active_color:expr, $text:expr, $timer:expr) => {
-        if $active {
-            $text.sections[1].style.color = $active_color;
-        } else {
-            $text.sections[1].style.color = Color::NONE;
-        }
-
-        $timer.0.reset();
-    };
-}
-
 fn keyboard(
     mut events: EventReader<KeyboardInput>,
-    mut text_input_query: Query<(
-        Entity,
-        &TextInputInactive,
-        &TextInputTextStyle,
-        &mut TextInput,
-        &mut TextInputCursorTimer,
-    )>,
+    mut text_input_query: Query<(Entity, &TextInputInactive, &mut TextInput)>,
     mut inner_text: InnerText,
     mut submit_writer: EventWriter<TextInputSubmitEvent>,
 ) {
@@ -157,7 +137,7 @@ fn keyboard(
         return;
     }
 
-    for (input_entity, inactive, style, mut text_input, mut timer) in &mut text_input_query {
+    for (input_entity, inactive, mut text_input) in &mut text_input_query {
         if inactive.0 {
             continue;
         }
@@ -178,18 +158,22 @@ fn keyboard(
                     if let Some(behind) = text.sections[0].value.pop() {
                         text.sections[2].value.insert(0, behind);
                     }
+                    continue;
                 }
                 KeyCode::ArrowRight => {
                     if !text.sections[2].value.is_empty() {
                         let ahead = text.sections[2].value.remove(0);
                         text.sections[0].value.push(ahead);
                     }
+                    continue;
                 }
                 KeyCode::Backspace => {
                     text.sections[0].value.pop();
+                    continue;
                 }
                 KeyCode::Delete => {
                     text.sections[2].value = text.sections[2].value.chars().skip(1).collect();
+                    continue;
                 }
                 KeyCode::Enter => {
                     submitted_value = Some(format!(
@@ -203,6 +187,7 @@ fn keyboard(
                 }
                 KeyCode::Space => {
                     text.sections[0].value.push(' ');
+                    continue;
                 }
                 _ => {}
             }
@@ -210,8 +195,6 @@ fn keyboard(
             if let Key::Character(ref s) = event.logical_key {
                 text.sections[0].value.push_str(s.as_str());
             }
-
-            set_cursor!(true, style.0.color, text, timer);
         }
 
         let value = format!("{}{}", text.sections[0].value, text.sections[2].value);
@@ -308,7 +291,13 @@ fn blink_cursor(
             continue;
         };
 
-        set_cursor!(!inactive.0, style.0.color, text, timer);
+        text.sections[1].style.color = if inactive.0 {
+            Color::NONE
+        } else {
+            style.0.color
+        };
+
+        timer.0.reset();
     }
 }
 
@@ -335,9 +324,11 @@ fn show_hide_cursor(
             continue;
         };
 
-        let active = text.sections[1].style.color == Color::NONE;
-
-        set_cursor!(active, style.0.color, text, timer);
+        if text.sections[1].style.color != Color::NONE {
+            text.sections[1].style.color = Color::NONE;
+        } else {
+            text.sections[1].style.color = style.0.color;
+        }
     }
 }
 


### PR DESCRIPTION
Resets the cursor's timer on inputs (other than `KeyCode::Enter`), solving #17 

I'm not sure if this solution is ideal and aligns with the project's goals. Please let me know what you think.