### PR TITLE
Fix names of blink_cursor and show_hide_cursor being swapped

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,8 @@ fn create(
     }
 }
 
-fn blink_cursor(
+// Shows or hides the cursor based on the text input's `inactive` property.
+fn show_hide_cursor(
     mut input_query: Query<(
         Entity,
         &TextInputTextStyle,
@@ -301,7 +302,8 @@ fn blink_cursor(
     }
 }
 
-fn show_hide_cursor(
+// Blinks the cursor on a timer.
+fn blink_cursor(
     mut input_query: Query<(
         Entity,
         &TextInputTextStyle,


### PR DESCRIPTION
These two systems were named opposite of what they actually do. Oops.

I added some comments for clarity.