### PR TITLE
Add a setting to control behavior when enter is pressed

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,9 +1,7 @@
 //! An example showing a very basic implementation.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{
-    TextInputBundle, TextInputPlugin, TextInputSubmitEvent, TextInputTextStyle,
-};
+use bevy_simple_text_input::{TextInputBundle, TextInputPlugin, TextInputSubmitEvent};
 
 const BORDER_COLOR_ACTIVE: Color = Color::rgb(0.75, 0.52, 0.99);
 const TEXT_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
@@ -45,14 +43,11 @@ fn setup(mut commands: Commands) {
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle {
-                    text_style: TextInputTextStyle(TextStyle {
-                        font_size: 40.,
-                        color: TEXT_COLOR,
-                        ..default()
-                    }),
+                TextInputBundle::default().with_text_style(TextStyle {
+                    font_size: 40.,
+                    color: TEXT_COLOR,
                     ..default()
-                },
+                }),
             ));
         });
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,9 @@
 //! An example showing a very basic implementation.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{TextInputBundle, TextInputPlugin, TextInputSubmitEvent};
+use bevy_simple_text_input::{
+    TextInputBundle, TextInputPlugin, TextInputSubmitEvent, TextInputTextStyle,
+};
 
 const BORDER_COLOR_ACTIVE: Color = Color::rgb(0.75, 0.52, 0.99);
 const TEXT_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
@@ -43,11 +45,14 @@ fn setup(mut commands: Commands) {
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle::new(TextStyle {
-                    font_size: 40.,
-                    color: TEXT_COLOR,
+                TextInputBundle {
+                    text_style: TextInputTextStyle(TextStyle {
+                        font_size: 40.,
+                        color: TEXT_COLOR,
+                        ..default()
+                    }),
                     ..default()
-                }),
+                },
             ));
         });
 }

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -1,9 +1,7 @@
 //! An example showing a more advanced implementation with focus.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{
-    TextInputBundle, TextInputInactive, TextInputPlugin, TextInputTextStyle, TextInputValue,
-};
+use bevy_simple_text_input::{TextInputBundle, TextInputInactive, TextInputPlugin};
 
 const BORDER_COLOR_ACTIVE: Color = Color::rgb(0.75, 0.52, 0.99);
 const BORDER_COLOR_INACTIVE: Color = Color::rgb(0.25, 0.25, 0.25);
@@ -51,16 +49,14 @@ fn setup(mut commands: Commands) {
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle {
-                    text_style: TextInputTextStyle(TextStyle {
+                TextInputBundle::default()
+                    .with_text_style(TextStyle {
                         font_size: 40.,
                         color: TEXT_COLOR,
                         ..default()
-                    }),
-                    value: TextInputValue("Click Me".to_owned()),
-                    inactive: TextInputInactive(true),
-                    ..default()
-                },
+                    })
+                    .with_value("Click Me".to_owned())
+                    .with_inactive(true),
             ));
         });
 }

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -1,7 +1,9 @@
 //! An example showing a more advanced implementation with focus.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{TextInputBundle, TextInputInactive, TextInputPlugin};
+use bevy_simple_text_input::{
+    TextInputBundle, TextInputInactive, TextInputPlugin, TextInputTextStyle, TextInputValue,
+};
 
 const BORDER_COLOR_ACTIVE: Color = Color::rgb(0.75, 0.52, 0.99);
 const BORDER_COLOR_INACTIVE: Color = Color::rgb(0.25, 0.25, 0.25);
@@ -45,18 +47,20 @@ fn setup(mut commands: Commands) {
                         padding: UiRect::all(Val::Px(5.0)),
                         ..default()
                     },
-                    border_color: BORDER_COLOR_ACTIVE.into(),
+                    border_color: BORDER_COLOR_INACTIVE.into(),
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle::with_starting_text(
-                    TextStyle {
+                TextInputBundle {
+                    text_style: TextInputTextStyle(TextStyle {
                         font_size: 40.,
                         color: TEXT_COLOR,
                         ..default()
-                    },
-                    "hello".to_owned(),
-                ),
+                    }),
+                    value: TextInputValue("Click Me".to_owned()),
+                    inactive: TextInputInactive(true),
+                    ..default()
+                },
             ));
         });
 }

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -1,7 +1,9 @@
 //! An example showing a very basic implementation.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{TextInput, TextInputBundle, TextInputPlugin};
+use bevy_simple_text_input::{
+    TextInputBundle, TextInputPlugin, TextInputSettings, TextInputTextStyle, TextInputValue,
+};
 
 const BORDER_COLOR_ACTIVE: Color = Color::rgb(0.75, 0.52, 0.99);
 const BORDER_COLOR_INACTIVE: Color = Color::rgb(0.25, 0.25, 0.25);
@@ -55,7 +57,14 @@ fn setup(mut commands: Commands) {
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle::with_starting_text(text_style.clone(), "1".to_string()),
+                TextInputBundle {
+                    settings: TextInputSettings {
+                        retain_on_submit: true,
+                    },
+                    value: TextInputValue("1".to_string()),
+                    text_style: TextInputTextStyle(text_style.clone()),
+                    ..default()
+                },
             ));
 
             parent
@@ -82,7 +91,7 @@ fn setup(mut commands: Commands) {
 
 fn button_system(
     interaction_query: Query<&Interaction, (Changed<Interaction>, With<IncValueButton>)>,
-    mut text_input_query: Query<&mut TextInput>,
+    mut text_input_query: Query<&mut TextInputValue>,
 ) {
     for interaction in &interaction_query {
         if !matches!(interaction, Interaction::Pressed) {

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -1,9 +1,7 @@
 //! An example showing a very basic implementation.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{
-    TextInputBundle, TextInputPlugin, TextInputSettings, TextInputTextStyle, TextInputValue,
-};
+use bevy_simple_text_input::{TextInputBundle, TextInputPlugin, TextInputSettings, TextInputValue};
 
 const BORDER_COLOR_ACTIVE: Color = Color::rgb(0.75, 0.52, 0.99);
 const BORDER_COLOR_INACTIVE: Color = Color::rgb(0.25, 0.25, 0.25);
@@ -57,14 +55,12 @@ fn setup(mut commands: Commands) {
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle {
-                    settings: TextInputSettings {
+                TextInputBundle::default()
+                    .with_text_style(text_style.clone())
+                    .with_value("1".to_owned())
+                    .with_settings(TextInputSettings {
                         retain_on_submit: true,
-                    },
-                    value: TextInputValue("1".to_string()),
-                    text_style: TextInputTextStyle(text_style.clone()),
-                    ..default()
-                },
+                    }),
             ));
 
             parent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,33 @@ pub struct TextInputBundle {
     /// This component's value is managed by Bevy's UI systems and enables tracking of hovers and presses.
     pub interaction: Interaction,
 }
+
+impl TextInputBundle {
+    /// Returns this [`TextInputBundle`] with a new [`TextInputValue`] containing the provided `String`.
+    pub fn with_value(mut self, value: String) -> Self {
+        self.value = TextInputValue(value);
+        self
+    }
+
+    /// Returns this [`TextInputBundle`] with a new [`TextInputTextStyle`] containing the provided `TextStyle`.
+    pub fn with_text_style(mut self, text_style: TextStyle) -> Self {
+        self.text_style = TextInputTextStyle(text_style);
+        self
+    }
+
+    /// Returns this [`TextInputBundle`] with a new [`TextInputInactive`] containing the provided `bool`.
+    pub fn with_inactive(mut self, inactive: bool) -> Self {
+        self.inactive = TextInputInactive(inactive);
+        self
+    }
+
+    /// Returns this [`TextInputBundle`] with a new [`TextInputSettings`].
+    pub fn with_settings(mut self, settings: TextInputSettings) -> Self {
+        self.settings = settings;
+        self
+    }
+}
+
 /// The [`TextStyle`] that will be used when creating the text input's inner [`TextBundle`].
 #[derive(Component, Default, Reflect)]
 pub struct TextInputTextStyle(pub TextStyle);


### PR DESCRIPTION
Fixes #32 

This also removes the constructors for `TextBundle` which is a bit of a bummer. I played with adding more constructors and adding a builder interface but felt like it added too much code.

I may still add a single `new(value: String, style: TextStyle)` which I think would be convenient for most uses.