### PR TITLE
Fix cursor moving to the end when using the delete key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,7 @@ fn keyboard(
                 KeyCode::Delete => {
                     if pos < text_input.0.len() {
                         text_input.0.remove(pos);
+                        cursor_pos.0 -= 0;
                         cursor_timer.should_reset = true;
                         continue;
                     }


### PR DESCRIPTION
fix cursor to the end of line when delete a char with del key.
