### PR TITLE
Fix cursor moving to the end when using the delete key

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,7 @@ fn keyboard(
                 KeyCode::Delete => {
                     if pos < text_input.0.len() {
                         text_input.0 = remove_char_at(&text_input.0, cursor_pos.0);
+                        cursor_pos.0 -= 0;
 
                         cursor_timer.should_reset = true;
                         continue;


### PR DESCRIPTION
This was done in #46, but accidentally merged into the wrong branch.