### PR TITLE
Define `TextInputSystem` system set

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,9 @@
 //! An example showing a very basic implementation.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{TextInputBundle, TextInputPlugin, TextInputSubmitEvent};
+use bevy_simple_text_input::{
+    TextInputBundle, TextInputPlugin, TextInputSubmitEvent, TextInputSystem,
+};
 
 const BORDER_COLOR_ACTIVE: Color = Color::rgb(0.75, 0.52, 0.99);
 const TEXT_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);
@@ -12,7 +14,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(TextInputPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, listener)
+        .add_systems(Update, listener.after(TextInputSystem))
         .run();
 }
 

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -1,7 +1,9 @@
 //! An example showing a more advanced implementation with focus.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{TextInputBundle, TextInputInactive, TextInputPlugin};
+use bevy_simple_text_input::{
+    TextInputBundle, TextInputInactive, TextInputPlugin, TextInputSystem,
+};
 
 const BORDER_COLOR_ACTIVE: Color = Color::rgb(0.75, 0.52, 0.99);
 const BORDER_COLOR_INACTIVE: Color = Color::rgb(0.25, 0.25, 0.25);
@@ -13,7 +15,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(TextInputPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, focus)
+        .add_systems(Update, focus.before(TextInputSystem))
         .run();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,10 @@ use bevy::{
 /// A Bevy `Plugin` providing the systems and assets required to make a [`TextInputBundle`] work.
 pub struct TextInputPlugin;
 
+/// Label for systems that update text inputs.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
+pub struct TextInputSystem;
+
 impl Plugin for TextInputPlugin {
     fn build(&self, app: &mut App) {
         // This is a special font with a zero-width `|` glyph.
@@ -54,7 +58,8 @@ impl Plugin for TextInputPlugin {
                     show_hide_cursor,
                     update_style,
                     show_hide_placeholder,
-                ),
+                )
+                    .in_set(TextInputSystem),
             )
             .register_type::<TextInputSettings>()
             .register_type::<TextInputTextStyle>()


### PR DESCRIPTION
This allows users to force their systems to run after this library's systems have run, for example to avoid a 1-frame delay between `TextInputSubmitEvent` being send and a downstream system picking it up.