### PR TITLE
add a few navigation shortcuts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,44 +189,71 @@ pub struct TextInputSettings {
 }
 
 /// text navigation actions that can be bound via TextInputNavigationBindings
+#[derive(Debug)]
 pub enum TextInputAction {
-    /// Move to start of line
+    /// char left
+    CharLeft,
+    /// char right
+    CharRight,
+    /// start of line
     LineStart,
-    /// Move to end of line
+    /// end of line
     LineEnd,
     /// word left
     WordLeft,
     /// word right
     WordRight,
+    /// backspace
+    DeletePrev,
+    /// delete
+    DeleteNext,
+    /// enter
+    Submit,
 }
-/// A resource in which key bindings can be specified. All keys must be pressed simultaneously to perform the action.
-/// The first action will be performed, so a binding that is the same as another with additional modifier keys should
-/// be earlier in the vector to be applied.
+/// A resource in which key bindings can be specified. Bindings are given as a tuple of (Primary Key, Modifiers).
+/// All modifiers must be held when the primary key is pressed to perform the action.
+/// The first matching action in the list will be performed, so a binding that is the same as another with additional
+/// modifier keys should be earlier in the vector to be applied.
 #[derive(Resource)]
-pub struct TextInputNavigationBindings(pub Vec<(TextInputAction, Vec<KeyCode>)>);
+pub struct TextInputNavigationBindings(pub Vec<(TextInputAction, TextInputBinding)>);
+
+/// A binding for text navigation
+pub struct TextInputBinding {
+    /// primary key
+    key: KeyCode,
+    /// required modifiers
+    modifiers: Vec<KeyCode>,
+}
+
+impl TextInputBinding {
+    /// new
+    pub fn new(key: KeyCode, modifiers: impl Into<Vec<KeyCode>>) -> Self {
+        Self {
+            key,
+            modifiers: modifiers.into(),
+        }
+    }
+}
 
 #[cfg(not(target_os = "macos"))]
 impl Default for TextInputNavigationBindings {
     fn default() -> Self {
+        use KeyCode::*;
+        use TextInputAction::*;
         Self(vec![
-            (TextInputAction::LineStart, vec![KeyCode::Home]),
-            (TextInputAction::LineEnd, vec![KeyCode::End]),
-            (
-                TextInputAction::WordLeft,
-                vec![KeyCode::ControlLeft, KeyCode::ArrowLeft],
-            ),
-            (
-                TextInputAction::WordLeft,
-                vec![KeyCode::ControlRight, KeyCode::ArrowLeft],
-            ),
-            (
-                TextInputAction::WordRight,
-                vec![KeyCode::ControlLeft, KeyCode::ArrowRight],
-            ),
-            (
-                TextInputAction::WordRight,
-                vec![KeyCode::ControlRight, KeyCode::ArrowRight],
-            ),
+            (LineStart, TextInputBinding::new(Home, [])),
+            (LineEnd, TextInputBinding::new(End, [])),
+            (WordLeft, TextInputBinding::new(ArrowLeft, [ControlLeft])),
+            (WordLeft, TextInputBinding::new(ArrowLeft, [ControlRight])),
+            (WordRight, TextInputBinding::new(ArrowRight, [ControlLeft])),
+            (WordRight, TextInputBinding::new(ArrowRight, [ControlRight])),
+            (CharLeft, TextInputBinding::new(ArrowLeft, [])),
+            (CharRight, TextInputBinding::new(ArrowRight, [])),
+            (DeletePrev, TextInputBinding::new(Backspace, [])),
+            (DeletePrev, TextInputBinding::new(NumpadBackspace, [])),
+            (DeleteNext, TextInputBinding::new(Delete, [])),
+            (Submit, TextInputBinding::new(Enter, [])),
+            (Submit, TextInputBinding::new(NumpadEnter, [])),
         ])
     }
 }
@@ -234,39 +261,24 @@ impl Default for TextInputNavigationBindings {
 #[cfg(target_os = "macos")]
 impl Default for TextInputNavigationBindings {
     fn default() -> Self {
+        use KeyCode::*;
+        use TextInputAction::*;
         Self(vec![
-            (
-                TextInputAction::LineStart,
-                vec![KeyCode::SuperLeft, KeyCode::ArrowLeft],
-            ),
-            (
-                TextInputAction::LineStart,
-                vec![KeyCode::SuperRight, KeyCode::ArrowLeft],
-            ),
-            (
-                TextInputAction::LineEnd,
-                vec![KeyCode::SuperLeft, KeyCode::ArrowRight],
-            ),
-            (
-                TextInputAction::LineEnd,
-                vec![KeyCode::SuperRight, KeyCode::ArrowRight],
-            ),
-            (
-                TextInputAction::WordLeft,
-                vec![KeyCode::AltLeft, KeyCode::ArrowLeft],
-            ),
-            (
-                TextInputAction::WordLeft,
-                vec![KeyCode::AltRight, KeyCode::ArrowLeft],
-            ),
-            (
-                TextInputAction::WordRight,
-                vec![KeyCode::AltLeft, KeyCode::ArrowRight],
-            ),
-            (
-                TextInputAction::WordRight,
-                vec![KeyCode::AltRight, KeyCode::ArrowRight],
-            ),
+            (LineStart, TextInputBinding::new(ArrowLeft, [SuperLeft])),
+            (LineStart, TextInputBinding::new(ArrowLeft, [SuperRight])),
+            (LineEnd, TextInputBinding::new(ArrowRight, [SuperLeft])),
+            (LineEnd, TextInputBinding::new(ArrowRight, [SuperRight])),
+            (WordLeft, TextInputBinding::new(ArrowLeft, [AltLeft])),
+            (WordLeft, TextInputBinding::new(ArrowLeft, [AltRight])),
+            (WordRight, TextInputBinding::new(ArrowRight, [AltLeft])),
+            (WordRight, TextInputBinding::new(ArrowRight, [AltRight])),
+            (CharLeft, TextInputBinding::new(ArrowLeft, [])),
+            (CharRight, TextInputBinding::new(ArrowRight, [])),
+            (DeletePrev, TextInputBinding::new(Backspace, [])),
+            (DeletePrev, TextInputBinding::new(NumpadBackspace, [])),
+            (DeleteNext, TextInputBinding::new(Delete, [])),
+            (Submit, TextInputBinding::new(Enter, [])),
+            (Submit, TextInputBinding::new(NumpadEnter, [])),
         ])
     }
 }
@@ -339,14 +351,17 @@ fn keyboard(
         return;
     }
 
-    'text_input: for (
-        input_entity,
-        settings,
-        inactive,
-        mut text_input,
-        mut cursor_pos,
-        mut cursor_timer,
-    ) in &mut text_input_query
+    // collect actions that have all required modifiers held
+    let valid_actions = navigation
+        .0
+        .iter()
+        .filter(|(_, TextInputBinding { modifiers, .. })| {
+            modifiers.iter().all(|m| key_input.pressed(*m))
+        })
+        .map(|(action, TextInputBinding { key, .. })| (*key, action));
+
+    for (input_entity, settings, inactive, mut text_input, mut cursor_pos, mut cursor_timer) in
+        &mut text_input_query
     {
         if inactive.0 {
             continue;
@@ -354,14 +369,25 @@ fn keyboard(
 
         let mut submitted_value = None;
 
-        for (action, chord) in navigation.0.iter() {
-            if chord.iter().all(|key| key_input.pressed(*key))
-                && chord.iter().any(|key| key_input.just_pressed(*key))
+        for input in input_reader.clone().read(&input_events) {
+            if !input.state.is_pressed() {
+                continue;
+            };
+
+            let pos = cursor_pos.bypass_change_detection().0;
+
+            if let Some((_, action)) = valid_actions
+                .clone()
+                .find(|(key, _)| *key == input.key_code)
             {
+                use TextInputAction::*;
+                let mut timer_should_reset = true;
                 match action {
-                    TextInputAction::LineStart => cursor_pos.0 = 0,
-                    TextInputAction::LineEnd => cursor_pos.0 = text_input.0.len(),
-                    TextInputAction::WordLeft => {
+                    CharLeft => cursor_pos.0 = cursor_pos.0.saturating_sub(1),
+                    CharRight => cursor_pos.0 = (cursor_pos.0 + 1).min(text_input.0.len()),
+                    LineStart => cursor_pos.0 = 0,
+                    LineEnd => cursor_pos.0 = text_input.0.len(),
+                    WordLeft => {
                         cursor_pos.0 = text_input
                             .0
                             .char_indices()
@@ -372,7 +398,7 @@ fn keyboard(
                             .map(|(ix, _)| ix + 1)
                             .unwrap_or(0)
                     }
-                    TextInputAction::WordRight => {
+                    WordRight => {
                         cursor_pos.0 = text_input
                             .0
                             .char_indices()
@@ -382,84 +408,52 @@ fn keyboard(
                             .map(|(ix, _)| ix)
                             .unwrap_or(text_input.0.len())
                     }
-                };
-                cursor_timer.should_reset = true;
-                continue 'text_input;
-            }
-        }
+                    DeletePrev => {
+                        if pos > 0 {
+                            cursor_pos.0 -= 1;
+                            text_input.0 = remove_char_at(&text_input.0, cursor_pos.0);
+                        }
+                    }
+                    DeleteNext => {
+                        if pos < text_input.0.len() {
+                            text_input.0 = remove_char_at(&text_input.0, cursor_pos.0);
 
-        for input in input_reader.clone().read(&input_events) {
-            if !input.state.is_pressed() {
+                            // Ensure that the cursor isn't reset
+                            cursor_pos.set_changed();
+                        }
+                    }
+                    Submit => {
+                        if settings.retain_on_submit {
+                            submitted_value = Some(text_input.0.clone());
+                        } else {
+                            submitted_value = Some(std::mem::take(&mut text_input.0));
+                            cursor_pos.0 = 0;
+                        };
+                        timer_should_reset = false;
+                    }
+                }
+
+                cursor_timer.should_reset |= timer_should_reset;
                 continue;
-            };
+            }
 
-            let pos = cursor_pos.bypass_change_detection().0;
-
-            match input.key_code {
-                KeyCode::ArrowLeft => {
-                    if pos > 0 {
-                        cursor_pos.0 -= 1;
-
-                        cursor_timer.should_reset = true;
-                        continue;
-                    }
-                }
-                KeyCode::ArrowRight => {
-                    if pos < text_input.0.len() {
-                        cursor_pos.0 += 1;
-
-                        cursor_timer.should_reset = true;
-                        continue;
-                    }
-                }
-                KeyCode::Backspace => {
-                    if pos > 0 {
-                        cursor_pos.0 -= 1;
-                        text_input.0 = remove_char_at(&text_input.0, cursor_pos.0);
-
-                        cursor_timer.should_reset = true;
-                        continue;
-                    }
-                }
-                KeyCode::Delete => {
-                    if pos < text_input.0.len() {
-                        text_input.0 = remove_char_at(&text_input.0, cursor_pos.0);
-
-                        // Ensure that the cursor isn't reset
-                        cursor_pos.set_changed();
-
-                        cursor_timer.should_reset = true;
-                        continue;
-                    }
-                }
-                KeyCode::Enter => {
-                    if settings.retain_on_submit {
-                        submitted_value = Some(text_input.0.clone());
-                    } else {
-                        submitted_value = Some(std::mem::take(&mut text_input.0));
-                        cursor_pos.0 = 0;
-                    };
-
-                    continue;
-                }
-                KeyCode::Space => {
+            match input.logical_key {
+                Key::Space => {
                     text_input.0.insert(pos, ' ');
                     cursor_pos.0 += 1;
 
                     cursor_timer.should_reset = true;
-                    continue;
                 }
-                _ => {}
-            }
+                Key::Character(ref s) => {
+                    let before = text_input.0.chars().take(cursor_pos.0);
+                    let after = text_input.0.chars().skip(cursor_pos.0);
+                    text_input.0 = before.chain(s.chars()).chain(after).collect();
 
-            if let Key::Character(ref s) = input.logical_key {
-                let before = text_input.0.chars().take(cursor_pos.0);
-                let after = text_input.0.chars().skip(cursor_pos.0);
-                text_input.0 = before.chain(s.chars()).chain(after).collect();
+                    cursor_pos.0 += 1;
 
-                cursor_pos.0 += 1;
-
-                cursor_timer.should_reset = true;
+                    cursor_timer.should_reset = true;
+                }
+                _ => (),
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,42 +234,40 @@ impl Default for TextInputNavigationBindings {
 #[cfg(target_os = "macos")]
 impl Default for TextInputNavigationBindings {
     fn default() -> Self {
-        fn default() -> Self {
-            Self(vec![
-                (
-                    TextInputAction::LineStart,
-                    vec![KeyCode::SuperLeft, KeyCode::ArrowLeft],
-                ),
-                (
-                    TextInputAction::LineStart,
-                    vec![KeyCode::SuperRight, KeyCode::ArrowLeft],
-                ),
-                (
-                    TextInputAction::LineEnd,
-                    vec![KeyCode::SuperLeft, KeyCode::ArrowRight],
-                ),
-                (
-                    TextInputAction::LineEnd,
-                    vec![KeyCode::SuperRight, KeyCode::ArrowRight],
-                ),
-                (
-                    TextInputAction::WordLeft,
-                    vec![KeyCode::AltLeft, KeyCode::ArrowLeft],
-                ),
-                (
-                    TextInputAction::WordLeft,
-                    vec![KeyCode::AltRight, KeyCode::ArrowLeft],
-                ),
-                (
-                    TextInputAction::WordRight,
-                    vec![KeyCode::AltLeft, KeyCode::ArrowRight],
-                ),
-                (
-                    TextInputAction::WordRight,
-                    vec![KeyCode::AltRight, KeyCode::ArrowRight],
-                ),
-            ])
-        }
+        Self(vec![
+            (
+                TextInputAction::LineStart,
+                vec![KeyCode::SuperLeft, KeyCode::ArrowLeft],
+            ),
+            (
+                TextInputAction::LineStart,
+                vec![KeyCode::SuperRight, KeyCode::ArrowLeft],
+            ),
+            (
+                TextInputAction::LineEnd,
+                vec![KeyCode::SuperLeft, KeyCode::ArrowRight],
+            ),
+            (
+                TextInputAction::LineEnd,
+                vec![KeyCode::SuperRight, KeyCode::ArrowRight],
+            ),
+            (
+                TextInputAction::WordLeft,
+                vec![KeyCode::AltLeft, KeyCode::ArrowLeft],
+            ),
+            (
+                TextInputAction::WordLeft,
+                vec![KeyCode::AltRight, KeyCode::ArrowLeft],
+            ),
+            (
+                TextInputAction::WordRight,
+                vec![KeyCode::AltLeft, KeyCode::ArrowRight],
+            ),
+            (
+                TextInputAction::WordRight,
+                vec![KeyCode::AltRight, KeyCode::ArrowRight],
+            ),
+        ])
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ use bevy::{
     ecs::system::SystemParam,
     input::keyboard::{Key, KeyboardInput},
     prelude::*,
-    text::BreakLineOn,
+    text::{BreakLineOn, TextLayoutInfo},
 };
 
 /// A Bevy `Plugin` providing the systems and assets required to make a [`TextInputBundle`] work.
@@ -58,6 +58,7 @@ impl Plugin for TextInputPlugin {
                     show_hide_cursor,
                     update_style,
                     show_hide_placeholder,
+                    scroll_with_cursor,
                 )
                     .in_set(TextInputSystem),
             )
@@ -374,6 +375,59 @@ fn update_value(
             cursor_pos.0,
             &mut text.sections,
         );
+    }
+}
+
+fn scroll_with_cursor(
+    mut texts: Query<
+        (&TextLayoutInfo, &mut Style, &Node, &Parent),
+        (With<TextInputInner>, Changed<TextLayoutInfo>),
+    >,
+    mut parents: Query<(&Node, &mut Style), Without<TextInputInner>>,
+) {
+    for (layout, mut style, child_node, parent) in texts.iter_mut() {
+        let Ok((parent_node, mut parent_style)) = parents.get_mut(parent.get()) else {
+            continue;
+        };
+
+        match layout.glyphs.last().map(|g| g.section_index) {
+            // no text -> do nothing
+            None => return,
+            // if cursor is at the end, position at FlexEnd so newly typed text does not take a frame to move into view
+            Some(1) => {
+                style.left = Val::Auto;
+                parent_style.justify_content = JustifyContent::FlexEnd;
+                return;
+            }
+            _ => (),
+        }
+
+        // if cursor is in the middle, we use FlexStart + `left` px for consistent behaviour when typing the middle
+        let child_size = child_node.size().x;
+        let parent_size = parent_node.size().x;
+
+        let Some(cursor_pos) = layout
+            .glyphs
+            .iter()
+            .find(|g| g.section_index == 1)
+            .map(|p| p.position.x)
+        else {
+            continue;
+        };
+
+        let box_pos = match style.left {
+            Val::Px(px) => -px,
+            _ => child_size - parent_size,
+        };
+
+        let relative_pos = cursor_pos - box_pos;
+
+        if relative_pos < 0.0 || relative_pos > parent_size {
+            let req_px = parent_size * 0.5 - cursor_pos;
+            let req_px = req_px.clamp(parent_size - child_size, 0.0);
+            style.left = Val::Px(req_px);
+            parent_style.justify_content = JustifyContent::FlexStart;
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,7 +200,7 @@ pub enum TextInputAction {
     WordRight,
 }
 /// A resource in which key bindings can be specified. All keys must be pressed simultaneously to perform the action.
-/// The first action will be performed, so a binding that is the same as another with additional modifier keys should 
+/// The first action will be performed, so a binding that is the same as another with additional modifier keys should
 /// be earlier in the vector to be applied.
 #[derive(Resource)]
 pub struct TextInputNavigationBindings(pub Vec<(TextInputAction, Vec<KeyCode>)>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,6 +367,7 @@ fn keyboard(
                             .char_indices()
                             .rev()
                             .skip(text_input.0.len() - cursor_pos.0 + 1)
+                            .skip_while(|c| c.1.is_ascii_whitespace())
                             .find(|c| c.1.is_ascii_whitespace())
                             .map(|(ix, _)| ix + 1)
                             .unwrap_or(0)
@@ -376,8 +377,9 @@ fn keyboard(
                             .0
                             .char_indices()
                             .skip(cursor_pos.0)
-                            .find(|c| c.1.is_ascii_whitespace())
-                            .map(|(ix, _)| ix + 1)
+                            .skip_while(|c| !c.1.is_ascii_whitespace())
+                            .find(|c| !c.1.is_ascii_whitespace())
+                            .map(|(ix, _)| ix)
                             .unwrap_or(text_input.0.len())
                     }
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,38 +388,6 @@ fn keyboard(
             }
         }
 
-        for (action, chord) in navigation.0.iter() {
-            if chord.iter().all(|key| key_input.pressed(*key))
-                && chord.iter().any(|key| key_input.just_pressed(*key))
-            {
-                match action {
-                    TextInputAction::LineStart => cursor_pos.0 = 0,
-                    TextInputAction::LineEnd => cursor_pos.0 = text_input.0.len(),
-                    TextInputAction::WordLeft => {
-                        cursor_pos.0 = text_input
-                            .0
-                            .char_indices()
-                            .rev()
-                            .skip(text_input.0.len() - cursor_pos.0 + 1)
-                            .find(|c| c.1.is_ascii_whitespace())
-                            .map(|(ix, _)| ix + 1)
-                            .unwrap_or(0)
-                    }
-                    TextInputAction::WordRight => {
-                        cursor_pos.0 = text_input
-                            .0
-                            .char_indices()
-                            .skip(cursor_pos.0)
-                            .find(|c| c.1.is_ascii_whitespace())
-                            .map(|(ix, _)| ix + 1)
-                            .unwrap_or(text_input.0.len())
-                    }
-                };
-                cursor_timer.should_reset = true;
-                continue 'text_input;
-            }
-        }
-
         for input in input_reader.clone().read(&input_events) {
             if !input.state.is_pressed() {
                 continue;


### PR DESCRIPTION
adds support for (configurable) word left/right and line start/end navigation.

i'm in the process of removing egui from my app, and text entry is the main blocker. to that end i hope to also add support for
- copy/paste
- multiline entry
- selection hilighting
- mouse interactions (though i suspect this won't be upstreamed easily)

i fully understand if you think this pr and these other features are out of scope of a "simple" text entry field though.