### PR TITLE
Make `create` system an observer

### DIFF
--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -49,6 +49,9 @@ fn setup(mut commands: Commands) {
                     },
                     border_color: BORDER_COLOR_INACTIVE.into(),
                     background_color: BACKGROUND_COLOR.into(),
+                    // Prevent clicks on the input from also bubbling down to the container
+                    // behind it
+                    focus_policy: bevy::ui::FocusPolicy::Block,
                     ..default()
                 },
                 TextInputBundle::default()


### PR DESCRIPTION
Fixes #62 

This ensures that there's no state where `TextInputBundle` exists on an entity, but the necessary child components are not present.

This revealed a few bugs. I wouldn't be completely surprised if there were more.