### PR TITLE
Multiline support

### DIFF
--- a/examples/multiline.rs
+++ b/examples/multiline.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 use bevy_simple_text_input::{
-    TextInputBundle, TextInputPlugin, TextInputSettings, TextInputSubmitEvent, TextInputSystem
+    TextInputBundle, TextInputPlugin, TextInputSettings, TextInputSubmitEvent, TextInputSystem,
 };
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);

--- a/examples/multiline.rs
+++ b/examples/multiline.rs
@@ -1,0 +1,65 @@
+//! An example showing a very basic implementation.
+
+use bevy::prelude::*;
+use bevy_simple_text_input::{
+    TextInputBundle, TextInputPlugin, TextInputSettings, TextInputSubmitEvent, TextInputSystem
+};
+
+const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
+const TEXT_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
+const BACKGROUND_COLOR: Color = Color::srgb(0.15, 0.15, 0.15);
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(TextInputPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, listener.after(TextInputSystem))
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                ..default()
+            },
+            ..default()
+        })
+        .with_children(|parent| {
+            parent.spawn((
+                NodeBundle {
+                    style: Style {
+                        width: Val::Px(400.0),
+                        height: Val::Px(200.0),
+                        border: UiRect::all(Val::Px(5.0)),
+                        padding: UiRect::all(Val::Px(5.0)),
+                        ..default()
+                    },
+                    border_color: BORDER_COLOR_ACTIVE.into(),
+                    background_color: BACKGROUND_COLOR.into(),
+                    ..default()
+                },
+                TextInputBundle::default().with_text_style(TextStyle {
+                    font_size: 40.,
+                    color: TEXT_COLOR,
+                    ..default()
+                }).with_settings(TextInputSettings {
+                    multiline: true,
+                    ..Default::default()
+                }).with_value("one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty"),
+            ));
+        });
+}
+
+fn listener(mut events: EventReader<TextInputSubmitEvent>) {
+    for event in events.read() {
+        info!("{:?} submitted: {}", event.entity, event.value);
+    }
+}

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -52,6 +52,7 @@ fn setup(mut commands: Commands) {
                     .with_settings(TextInputSettings {
                         mask_character: Some('*'),
                         retain_on_submit: true,
+                        ..Default::default()
                     }),
             ));
         });


### PR DESCRIPTION
adds multiline support, including cursor up/down and start/end document navigation, and a `NewLine` action for inserting linebreaks.

two annoyances:
- when the cursor is in between the final char of one line and the first char of the next, it appears at the end of the line instead of the start of the following line. i considered adding some manual line break into the text-sections, but it's very messy. the alternative is to make the cursor a floating entity and not part of the text itself. this is pretty tricky while we can't properly determine the position of spaces (they have no `PositionedGlyph`s)
- sections breaks are interpreted by ab_glyph as word boundaries, so if you have the cursor in the middle of a word which has wrapped from a line above, it gets broken at the cursor. floating cursor would fix this, but cosmic text also fixes it on main