### PR TITLE
Fix events piling up and causing duplicate key presses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ impl<'w, 's> InnerText<'w, 's> {
 fn keyboard(
     key_input: Res<ButtonInput<KeyCode>>,
     input_events: Res<Events<KeyboardInput>>,
-    input_reader: Local<ManualEventReader<KeyboardInput>>,
+    mut input_reader: Local<ManualEventReader<KeyboardInput>>,
     mut text_input_query: Query<(
         Entity,
         &TextInputSettings,
@@ -466,6 +466,8 @@ fn keyboard(
             });
         }
     }
+
+    input_reader.clear(&input_events);
 }
 
 fn update_value(


### PR DESCRIPTION
Fixes an issue where duplicated events seemed to arrive when using a high refresh rate display.