### PR TITLE
Fix insertion of a space between multibyte characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,25 +441,15 @@ fn keyboard(
 
             match input.logical_key {
                 Key::Space => {
-                    let mut utf8_pos = 0;
-
-                    for (i, c) in text_input.0.chars().enumerate() {
-                        if i >= pos {
-                            break;
-                        }
-
-                        utf8_pos += c.len_utf8();
-                    }
-
-                    text_input.0.insert(utf8_pos, ' ');
+                    let byte_pos = byte_pos(&text_input.0, pos);
+                    text_input.0.insert(byte_pos, ' ');
                     cursor_pos.0 += 1;
 
                     cursor_timer.should_reset = true;
                 }
                 Key::Character(ref s) => {
-                    let before = text_input.0.chars().take(cursor_pos.0);
-                    let after = text_input.0.chars().skip(cursor_pos.0);
-                    text_input.0 = before.chain(s.chars()).chain(after).collect();
+                    let byte_pos = byte_pos(&text_input.0, pos);
+                    text_input.0.insert_str(byte_pos, s.as_str());
 
                     cursor_pos.0 += 1;
 
@@ -865,6 +855,14 @@ fn remove_char_at(input: &str, index: usize) -> String {
         .enumerate()
         .filter_map(|(i, c)| if i != index { Some(c) } else { None })
         .collect()
+}
+
+fn byte_pos(input: &str, char_pos: usize) -> usize {
+    let mut char_indices = input.char_indices();
+    char_indices
+        .nth(char_pos)
+        .map(|(pos, _)| pos)
+        .unwrap_or(input.len())
 }
 
 fn masked_value(value: &str, mask: Option<char>) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -441,7 +441,17 @@ fn keyboard(
 
             match input.logical_key {
                 Key::Space => {
-                    text_input.0.insert(pos, ' ');
+                    let mut utf8_pos = 0;
+
+                    for (i, c) in text_input.0.chars().enumerate() {
+                        if i >= pos {
+                            break;
+                        }
+
+                        utf8_pos += c.len_utf8();
+                    }
+
+                    text_input.0.insert(utf8_pos, ' ');
                     cursor_pos.0 += 1;
 
                     cursor_timer.should_reset = true;


### PR DESCRIPTION
Added a fix to correctly insert a space in strings containing multibyte characters. Previously, the space was inserted based on the character position, which caused issues with multibyte strings by attempting to insert the space between bytes of a multibyte character, leading to panics (`assertion failed: self.is_char_boundary(idx)`).

For example, the word `apple` has 5 bytes and 5 characters, so inserting a space with the old code works correctly. However, the Cyrillic word `яблоко` has 12 bytes and 6 characters. With the old code, inserting a space could put it inside a multibyte character, causing panic.