### PR TITLE
Upgrade to Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,6 @@ exclude = [".github"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-# Bevy needs either its `x11` or `wayland` features enabled to compile on linux.
-# By default, Bevy includes `x11`, so we will too.
-[features]
-default = ["x11"]
-x11 = ["bevy/x11"]
-
 [dependencies.bevy]
 version = "0.15.0-rc.1"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [".github"]
 [dependencies.bevy]
 version = "0.15"
 default-features = false
-features = ["bevy_ui", "bevy_asset", "bevy_text"]
+features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 
 [dev-dependencies.bevy]
 version = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ default = ["x11"]
 x11 = ["bevy/x11"]
 
 [dependencies.bevy]
-git = "https://github.com/bevyengine/bevy"
+version = "0.15.0-rc.1"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text"]
 
 [dev-dependencies.bevy]
-git = "https://github.com/bevyengine/bevy"
+version = "0.15.0-rc.1"
 default-features = true
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ exclude = [".github"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.bevy]
-version = "0.15.0-rc.1"
+version = "0.15"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text"]
 
 [dev-dependencies.bevy]
-version = "0.15.0-rc.1"
+version = "0.15"
 default-features = true
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 version = "0.15"
 default-features = true
 
-
 [lints.rust]
 missing_docs = "warn"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ exclude = [".github"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# Bevy needs either its `x11` or `wayland` features enabled to compile on linux.
+# By default, Bevy includes `x11`, so we will too.
+[features]
+default = ["x11"]
+x11 = ["bevy/x11"]
+
 [dependencies.bevy]
 git = "https://github.com/bevyengine/bevy"
 default-features = false
@@ -22,6 +28,7 @@ features = ["bevy_ui", "bevy_asset", "bevy_text"]
 [dev-dependencies.bevy]
 git = "https://github.com/bevyengine/bevy"
 default-features = true
+
 
 [lints.rust]
 missing_docs = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ exclude = [".github"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.bevy]
-version = "0.14"
+git = "https://github.com/bevyengine/bevy"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text"]
 
 [dev-dependencies.bevy]
-version = "0.14"
+git = "https://github.com/bevyengine/bevy"
 default-features = true
 
 [lints.rust]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 use bevy_simple_text_input::{
-    TextInputBundle, TextInputPlugin, TextInputSubmitEvent, TextInputSystem,
+    TextInput, TextInputPlugin, TextInputSubmitEvent, TextInputSystem, TextInputTextStyle,
 };
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
@@ -45,7 +45,8 @@ fn setup(mut commands: Commands) {
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle::default().with_text_style(TextStyle {
+                TextInput,
+                TextInputTextStyle(TextStyle {
                     font_size: 34.,
                     color: TEXT_COLOR,
                     ..default()

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -19,7 +19,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     commands
         .spawn(NodeBundle {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,7 +2,8 @@
 
 use bevy::prelude::*;
 use bevy_simple_text_input::{
-    TextInput, TextInputPlugin, TextInputSubmitEvent, TextInputSystem, TextInputTextStyle,
+    TextInput, TextInputPlugin, TextInputSubmitEvent, TextInputSystem, TextInputTextColor,
+    TextInputTextFont,
 };
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
@@ -46,11 +47,11 @@ fn setup(mut commands: Commands) {
                     ..default()
                 },
                 TextInput,
-                TextInputTextStyle(TextStyle {
+                TextInputTextFont(TextFont {
                     font_size: 34.,
-                    color: TEXT_COLOR,
                     ..default()
                 }),
+                TextInputTextColor(TextColor(TEXT_COLOR)),
             ));
         });
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -23,29 +23,23 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
     commands
-        .spawn(NodeBundle {
-            style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                ..default()
-            },
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
             ..default()
         })
         .with_children(|parent| {
             parent.spawn((
-                NodeBundle {
-                    style: Style {
-                        width: Val::Px(200.0),
-                        border: UiRect::all(Val::Px(5.0)),
-                        padding: UiRect::all(Val::Px(5.0)),
-                        ..default()
-                    },
-                    border_color: BORDER_COLOR_ACTIVE.into(),
-                    background_color: BACKGROUND_COLOR.into(),
+                Node {
+                    width: Val::Px(200.0),
+                    border: UiRect::all(Val::Px(5.0)),
+                    padding: UiRect::all(Val::Px(5.0)),
                     ..default()
                 },
+                BorderColor(BORDER_COLOR_ACTIVE),
+                BackgroundColor(BACKGROUND_COLOR),
                 TextInput,
                 TextInputTextFont(TextFont {
                     font_size: 34.,

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -46,7 +46,7 @@ fn setup(mut commands: Commands) {
                     ..default()
                 },
                 TextInputBundle::default().with_text_style(TextStyle {
-                    font_size: 40.,
+                    font_size: 34.,
                     color: TEXT_COLOR,
                     ..default()
                 }),

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -2,7 +2,8 @@
 
 use bevy::prelude::*;
 use bevy_simple_text_input::{
-    TextInputBundle, TextInputInactive, TextInputPlugin, TextInputSystem,
+    TextInput, TextInputInactive, TextInputPlaceholder, TextInputPlugin, TextInputSystem,
+    TextInputTextStyle,
 };
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
@@ -54,14 +55,17 @@ fn setup(mut commands: Commands) {
                     focus_policy: bevy::ui::FocusPolicy::Block,
                     ..default()
                 },
-                TextInputBundle::default()
-                    .with_text_style(TextStyle {
-                        font_size: 34.,
-                        color: TEXT_COLOR,
-                        ..default()
-                    })
-                    .with_placeholder("Click Me", None)
-                    .with_inactive(true),
+                TextInput,
+                TextInputTextStyle(TextStyle {
+                    font_size: 34.,
+                    color: TEXT_COLOR,
+                    ..default()
+                }),
+                TextInputPlaceholder {
+                    value: "Click Me".to_string(),
+                    text_style: None,
+                },
+                TextInputInactive(true),
             ));
         });
 }

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -56,7 +56,7 @@ fn setup(mut commands: Commands) {
                 },
                 TextInputBundle::default()
                     .with_text_style(TextStyle {
-                        font_size: 40.,
+                        font_size: 34.,
                         color: TEXT_COLOR,
                         ..default()
                     })

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -1,6 +1,6 @@
 //! An example showing a more advanced implementation with focus.
 
-use bevy::prelude::*;
+use bevy::{prelude::*, ui::FocusPolicy};
 use bevy_simple_text_input::{
     TextInput, TextInputInactive, TextInputPlaceholder, TextInputPlugin, TextInputSystem,
     TextInputTextColor, TextInputTextFont,
@@ -25,14 +25,11 @@ fn setup(mut commands: Commands) {
 
     commands
         .spawn((
-            NodeBundle {
-                style: Style {
-                    width: Val::Percent(100.0),
-                    height: Val::Percent(100.0),
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Center,
-                    ..default()
-                },
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
                 ..default()
             },
             // Make this container node bundle to be Interactive so that clicking on it removes
@@ -41,20 +38,17 @@ fn setup(mut commands: Commands) {
         ))
         .with_children(|parent| {
             parent.spawn((
-                NodeBundle {
-                    style: Style {
-                        width: Val::Px(200.0),
-                        border: UiRect::all(Val::Px(5.0)),
-                        padding: UiRect::all(Val::Px(5.0)),
-                        ..default()
-                    },
-                    border_color: BORDER_COLOR_INACTIVE.into(),
-                    background_color: BACKGROUND_COLOR.into(),
-                    // Prevent clicks on the input from also bubbling down to the container
-                    // behind it
-                    focus_policy: bevy::ui::FocusPolicy::Block,
+                Node {
+                    width: Val::Px(200.0),
+                    border: UiRect::all(Val::Px(5.0)),
+                    padding: UiRect::all(Val::Px(5.0)),
                     ..default()
                 },
+                BorderColor(BORDER_COLOR_INACTIVE),
+                BackgroundColor(BACKGROUND_COLOR),
+                // Prevent clicks on the input from also bubbling down to the container
+                // behind it
+                FocusPolicy::Block,
                 TextInput,
                 TextInputTextFont(TextFont {
                     font_size: 34.,

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 use bevy_simple_text_input::{
     TextInput, TextInputInactive, TextInputPlaceholder, TextInputPlugin, TextInputSystem,
-    TextInputTextStyle,
+    TextInputTextColor, TextInputTextFont,
 };
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
@@ -56,14 +56,14 @@ fn setup(mut commands: Commands) {
                     ..default()
                 },
                 TextInput,
-                TextInputTextStyle(TextStyle {
+                TextInputTextFont(TextFont {
                     font_size: 34.,
-                    color: TEXT_COLOR,
                     ..default()
                 }),
+                TextInputTextColor(TextColor(TEXT_COLOR)),
                 TextInputPlaceholder {
                     value: "Click Me".to_string(),
-                    text_style: None,
+                    ..default()
                 },
                 TextInputInactive(true),
             ));

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -21,7 +21,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     commands
         .spawn((

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -45,7 +45,7 @@ fn setup(mut commands: Commands) {
                 TextInputBundle::default()
                     .with_value("password")
                     .with_text_style(TextStyle {
-                        font_size: 40.,
+                        font_size: 34.,
                         color: TEXT_COLOR,
                         ..default()
                     })

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -2,7 +2,8 @@
 
 use bevy::prelude::*;
 use bevy_simple_text_input::{
-    TextInput, TextInputPlugin, TextInputSettings, TextInputTextStyle, TextInputValue,
+    TextInput, TextInputPlugin, TextInputSettings, TextInputTextColor, TextInputTextFont,
+    TextInputValue,
 };
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
@@ -46,11 +47,11 @@ fn setup(mut commands: Commands) {
                 },
                 TextInput,
                 TextInputValue("password".to_string()),
-                TextInputTextStyle(TextStyle {
+                TextInputTextFont(TextFont {
                     font_size: 34.,
-                    color: TEXT_COLOR,
                     ..default()
                 }),
+                TextInputTextColor(TextColor(TEXT_COLOR)),
                 TextInputSettings {
                     mask_character: Some('*'),
                     retain_on_submit: true,

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -1,7 +1,9 @@
 //! An example showing a masked input for passwords.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{TextInputBundle, TextInputPlugin, TextInputSettings};
+use bevy_simple_text_input::{
+    TextInput, TextInputPlugin, TextInputSettings, TextInputTextStyle, TextInputValue,
+};
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
 const TEXT_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
@@ -42,17 +44,17 @@ fn setup(mut commands: Commands) {
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle::default()
-                    .with_value("password")
-                    .with_text_style(TextStyle {
-                        font_size: 34.,
-                        color: TEXT_COLOR,
-                        ..default()
-                    })
-                    .with_settings(TextInputSettings {
-                        mask_character: Some('*'),
-                        retain_on_submit: true,
-                    }),
+                TextInput,
+                TextInputValue("password".to_string()),
+                TextInputTextStyle(TextStyle {
+                    font_size: 34.,
+                    color: TEXT_COLOR,
+                    ..default()
+                }),
+                TextInputSettings {
+                    mask_character: Some('*'),
+                    retain_on_submit: true,
+                },
             ));
         });
 }

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -22,29 +22,23 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
     commands
-        .spawn(NodeBundle {
-            style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                ..default()
-            },
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
             ..default()
         })
         .with_children(|parent| {
             parent.spawn((
-                NodeBundle {
-                    style: Style {
-                        width: Val::Px(200.0),
-                        border: UiRect::all(Val::Px(5.0)),
-                        padding: UiRect::all(Val::Px(5.0)),
-                        ..default()
-                    },
-                    border_color: BORDER_COLOR_ACTIVE.into(),
-                    background_color: BACKGROUND_COLOR.into(),
+                Node {
+                    width: Val::Px(200.0),
+                    border: UiRect::all(Val::Px(5.0)),
+                    padding: UiRect::all(Val::Px(5.0)),
                     ..default()
                 },
+                BorderColor(BORDER_COLOR_ACTIVE),
+                BackgroundColor(BACKGROUND_COLOR),
                 TextInput,
                 TextInputValue("password".to_string()),
                 TextInputTextFont(TextFont {

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -18,7 +18,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     commands
         .spawn(NodeBundle {

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -83,7 +83,7 @@ fn setup(mut commands: Commands) {
                     IncValueButton,
                 ))
                 .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section("+", text_style.clone()));
+                    parent.spawn((Text::new("+"), text_style.clone()));
                 });
         });
 }

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -24,7 +24,7 @@ fn main() {
 struct IncValueButton;
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     let text_style = TextStyle {
         font_size: 40.,

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -1,7 +1,9 @@
 //! An example showing a text input that is updated by a button.
 
 use bevy::prelude::*;
-use bevy_simple_text_input::{TextInputBundle, TextInputPlugin, TextInputSettings, TextInputValue};
+use bevy_simple_text_input::{
+    TextInput, TextInputPlugin, TextInputSettings, TextInputTextStyle, TextInputValue,
+};
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
 const BORDER_COLOR_INACTIVE: Color = Color::srgb(0.25, 0.25, 0.25);
@@ -55,13 +57,13 @@ fn setup(mut commands: Commands) {
                     background_color: BACKGROUND_COLOR.into(),
                     ..default()
                 },
-                TextInputBundle::default()
-                    .with_text_style(text_style.clone())
-                    .with_value("1")
-                    .with_settings(TextInputSettings {
-                        retain_on_submit: true,
-                        ..default()
-                    }),
+                TextInput,
+                TextInputTextStyle(text_style.clone()),
+                TextInputValue("1".to_string()),
+                TextInputSettings {
+                    retain_on_submit: true,
+                    ..default()
+                },
             ));
 
             parent

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -2,7 +2,8 @@
 
 use bevy::prelude::*;
 use bevy_simple_text_input::{
-    TextInput, TextInputPlugin, TextInputSettings, TextInputTextStyle, TextInputValue,
+    TextInput, TextInputPlugin, TextInputSettings, TextInputTextColor, TextInputTextFont,
+    TextInputValue,
 };
 
 const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
@@ -26,11 +27,11 @@ struct IncValueButton;
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
-    let text_style = TextStyle {
+    let text_font = TextFont {
         font_size: 40.,
-        color: TEXT_COLOR,
         ..default()
     };
+    let text_color = TextColor(TEXT_COLOR);
 
     commands
         .spawn(NodeBundle {
@@ -58,7 +59,8 @@ fn setup(mut commands: Commands) {
                     ..default()
                 },
                 TextInput,
-                TextInputTextStyle(text_style.clone()),
+                TextInputTextFont(text_font.clone()),
+                TextInputTextColor(text_color),
                 TextInputValue("1".to_string()),
                 TextInputSettings {
                     retain_on_submit: true,
@@ -83,7 +85,7 @@ fn setup(mut commands: Commands) {
                     IncValueButton,
                 ))
                 .with_children(|parent| {
-                    parent.spawn((Text::new("+"), text_style.clone()));
+                    parent.spawn((Text::new("+"), text_font, text_color));
                 });
         });
 }

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -34,30 +34,24 @@ fn setup(mut commands: Commands) {
     let text_color = TextColor(TEXT_COLOR);
 
     commands
-        .spawn(NodeBundle {
-            style: Style {
-                width: Val::Percent(100.0),
-                height: Val::Percent(100.0),
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                column_gap: Val::Px(10.),
-                ..default()
-            },
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            column_gap: Val::Px(10.),
             ..default()
         })
         .with_children(|parent| {
             parent.spawn((
-                NodeBundle {
-                    style: Style {
-                        width: Val::Px(200.0),
-                        border: UiRect::all(Val::Px(5.0)),
-                        padding: UiRect::all(Val::Px(5.0)),
-                        ..default()
-                    },
-                    border_color: BorderColor(BORDER_COLOR_ACTIVE),
-                    background_color: BACKGROUND_COLOR.into(),
+                Node {
+                    width: Val::Px(200.0),
+                    border: UiRect::all(Val::Px(5.0)),
+                    padding: UiRect::all(Val::Px(5.0)),
                     ..default()
                 },
+                BorderColor(BORDER_COLOR_ACTIVE),
+                BackgroundColor(BACKGROUND_COLOR),
                 TextInput,
                 TextInputTextFont(text_font.clone()),
                 TextInputTextColor(text_color),
@@ -70,18 +64,16 @@ fn setup(mut commands: Commands) {
 
             parent
                 .spawn((
-                    ButtonBundle {
-                        style: Style {
-                            width: Val::Px(50.),
-                            border: UiRect::all(Val::Px(5.0)),
-                            padding: UiRect::all(Val::Px(5.0)),
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        },
-                        border_color: BorderColor(BORDER_COLOR_INACTIVE),
-                        background_color: BACKGROUND_COLOR.into(),
+                    Button,
+                    Node {
+                        width: Val::Px(50.),
+                        border: UiRect::all(Val::Px(5.0)),
+                        padding: UiRect::all(Val::Px(5.0)),
+                        justify_content: JustifyContent::Center,
                         ..default()
                     },
+                    BorderColor(BORDER_COLOR_INACTIVE),
+                    BackgroundColor(BACKGROUND_COLOR),
                     IncValueButton,
                 ))
                 .with_children(|parent| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,14 +473,14 @@ fn scroll_with_cursor(
     mut inner_text_query: Query<
         (
             &TextLayoutInfo,
-            &mut Style,
-            &Node,
+            &mut Node,
+            &ComputedNode,
             &Parent,
             Option<&TargetCamera>,
         ),
         (With<TextInputInner>, Changed<TextLayoutInfo>),
     >,
-    mut style_query: Query<(&Node, &mut Style), Without<TextInputInner>>,
+    mut style_query: Query<(&ComputedNode, &mut Node), Without<TextInputInner>>,
     camera_query: Query<&Camera>,
     window_query: Query<&Window>,
     primary_window_query: Query<&Window, With<PrimaryWindow>>,
@@ -656,7 +656,7 @@ fn create(
                 } else {
                     Visibility::Hidden
                 },
-                Style {
+                Node {
                     position_type: PositionType::Absolute,
                     ..default()
                 },
@@ -665,13 +665,10 @@ fn create(
 
         let overflow_container = commands
             .spawn((
-                NodeBundle {
-                    style: Style {
-                        overflow: Overflow::clip(),
-                        justify_content: JustifyContent::FlexEnd,
-                        max_width: Val::Percent(100.),
-                        ..default()
-                    },
+                Node {
+                    overflow: Overflow::clip(),
+                    justify_content: JustifyContent::FlexEnd,
+                    max_width: Val::Percent(100.),
                     ..default()
                 },
                 Name::new("TextInputOverflowContainer"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 
 use bevy::{
     asset::load_internal_binary_asset,
-    ecs::{event::ManualEventReader, system::SystemParam},
+    ecs::{event::EventCursor, system::SystemParam},
     input::keyboard::{Key, KeyboardInput},
     prelude::*,
     render::camera::RenderTarget,
@@ -339,7 +339,7 @@ impl<'w, 's> InnerText<'w, 's> {
 fn keyboard(
     key_input: Res<ButtonInput<KeyCode>>,
     input_events: Res<Events<KeyboardInput>>,
-    mut input_reader: Local<ManualEventReader<KeyboardInput>>,
+    mut input_reader: Local<EventCursor<KeyboardInput>>,
     mut text_input_query: Query<(
         Entity,
         &TextInputSettings,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use bevy::{
     input::keyboard::{Key, KeyboardInput},
     prelude::*,
     render::camera::RenderTarget,
-    text::{BreakLineOn, TextLayoutInfo},
+    text::{LineBreak, TextLayoutInfo},
     ui::FocusPolicy,
     window::{PrimaryWindow, WindowRef},
 };
@@ -610,7 +610,7 @@ fn create(
             .spawn((
                 TextBundle {
                     text: Text {
-                        linebreak_behavior: BreakLineOn::NoWrap,
+                        linebreak: LineBreak::NoWrap,
                         sections,
                         ..default()
                     },
@@ -632,7 +632,7 @@ fn create(
             .spawn((
                 TextBundle {
                     text: Text {
-                        linebreak_behavior: BreakLineOn::NoWrap,
+                        linebreak: LineBreak::NoWrap,
                         sections: vec![TextSection {
                             value: placeholder.value.clone(),
                             style: placeholder_style,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ const CURSOR_HANDLE: Handle<Font> = Handle::weak_from_u128(10482756907980398621)
     TextInputCursorTimer,
     TextInputValue,
     TextInputPlaceholder,
+    Node,
     Interaction
 )]
 pub struct TextInput;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ struct InnerText<'w, 's> {
     text_query: Query<'w, 's, (), With<TextInputInner>>,
     children_query: Query<'w, 's, &'static Children>,
 }
-impl<'w, 's> InnerText<'w, 's> {
+impl InnerText<'_, '_> {
     fn inner_entity(&self, entity: Entity) -> Option<Entity> {
         self.children_query
             .iter_descendants(entity)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,7 +673,7 @@ fn create(
         commands.entity(overflow_container).add_child(text);
         commands
             .entity(trigger.entity())
-            .push_children(&[overflow_container, placeholder_text]);
+            .add_children(&[overflow_container, placeholder_text]);
 
         // Prevent clicks from registering on UI elements underneath the text input.
         commands.entity(trigger.entity()).insert(FocusPolicy::Block);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! }
 //!
 //! fn setup(mut commands: Commands) {
-//!     commands.spawn(Camera2dBundle::default());
+//!     commands.spawn(Camera2d);
 //!     commands.spawn((NodeBundle::default(), TextInput));
 //! }
 //! ```


### PR DESCRIPTION
This will have some minor breaking changes to align with Bevy's migration away from `Bundle`s to "required components." See the diffs for the examples.

There might be some minor shuffling related to that before merging this -- `TextInputSettings` may get merged with `TextInput`. Open to feedback there.

I want to avoid any other big changes and save them for a follow-up release.

I won't be doing a "release candidate" for this crate. You can use this branch as a git dependency.

```toml
[dependencies]
bevy_simple_text_input = { git = "https://github.com/rparrett/bevy_simple_text_input", branch = "bevy-0.15" }
```