### PR TITLE
Replace "return" with "continue" in scroll_with_cursor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,12 +493,12 @@ fn scroll_with_cursor(
 
         match layout.glyphs.last().map(|g| g.span_index) {
             // no text -> do nothing
-            None => return,
+            None => continue,
             // if cursor is at the end, position at FlexEnd so newly typed text does not take a frame to move into view
             Some(1) => {
                 style.left = Val::Auto;
                 parent_style.justify_content = JustifyContent::FlexEnd;
-                return;
+                continue;
             }
             _ => (),
         }


### PR DESCRIPTION
I was looking at the repo for inspiration and seemed to have found an apparent logical error: Throughout the `scroll_with_cursor` function, `continue` is used to ensure other text inputs in the query are handled even if one is skipped. This appears to not be true for one part of the code, where it `return`s instead.

I figured I would PR the presumed fix instead of just opening an issue, however I did NOT test this change, as I'm not a user of the code at this time. Hope this still helps.