### PR TITLE
Upgrade to Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,18 @@ categories = ["game-development"]
 readme = "README.md"
 exclude = [".github"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["std"]
+std = ["bevy/std"]
+libm = ["bevy/libm"]
 
 [dependencies.bevy]
-version = "0.15"
+git = "https://github.com/bevyengine/bevy.git"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 
 [dev-dependencies.bevy]
-version = "0.15"
+git = "https://github.com/bevyengine/bevy.git"
 default-features = true
 
 [lints.rust]

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -91,7 +91,9 @@ fn button_system(
             continue;
         }
 
-        let mut text_input = text_input_query.single_mut();
+        let Ok(mut text_input) = text_input_query.single_mut() else {
+            continue;
+        };
 
         let current_value = text_input.0.parse::<i32>().unwrap_or(0);
 


### PR DESCRIPTION
This is a barebones migration for now.

I may include:

- Removing the cursor font (enabled by the `cosmic-text` buffer becoming public)
- Using Bevy's built-in `InputFocus`

Pending time/motivation, or save them for a followup release.