### PR TITLE
Resolve system ordering ambiguities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,13 @@ impl Plugin for TextInputPlugin {
                 (
                     keyboard,
                     update_value.after(keyboard),
-                    blink_cursor,
-                    show_hide_cursor,
-                    update_style,
-                    update_color,
-                    show_hide_placeholder,
+                    (blink_cursor, show_hide_cursor, update_color)
+                        .chain()
+                        .after(keyboard)
+                        .ambiguous_with(update_value)
+                        .ambiguous_with(update_style),
+                    update_style.ambiguous_with(update_value),
+                    show_hide_placeholder.after(keyboard),
                     scroll_with_cursor,
                 )
                     .in_set(TextInputSystem),


### PR DESCRIPTION
When setting [`ScheduleBuildSettings::ambiguity_detection`](https://docs.rs/bevy/latest/bevy/ecs/schedule/struct.ScheduleBuildSettings.html#structfield.ambiguity_detection) I noticed a few warnings for ambiguities between systems in this crate. This PR fixes them.

The main conflict was on `TextUiWriter` which requires mutable access to several text components. `blink_cursor`, `show_hide_cursor`, `update_color` all update the cursor color so I declared a deterministic run order. In the other cases they set different properties of the text so I marked them as ambiguous. I also marked systems which use the text value or cursor timer as dependant on the `keyboard` system which sets those components.