### PR TITLE
feature: Character limit backport to version 0.10

### DIFF
--- a/examples/char-limit.rs
+++ b/examples/char-limit.rs
@@ -1,0 +1,61 @@
+//! An example showing a character limit.
+
+use bevy::prelude::*;
+use bevy_simple_text_input::{
+    TextInput, TextInputPlugin, TextInputSettings, TextInputSubmitEvent, TextInputSystem,
+    TextInputTextColor, TextInputTextFont,
+};
+
+const BORDER_COLOR_ACTIVE: Color = Color::srgb(0.75, 0.52, 0.99);
+const TEXT_COLOR: Color = Color::srgb(0.9, 0.9, 0.9);
+const BACKGROUND_COLOR: Color = Color::srgb(0.15, 0.15, 0.15);
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(TextInputPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, listener.after(TextInputSystem))
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2d);
+
+    commands
+        .spawn(Node {
+            width: Val::Percent(100.0),
+            height: Val::Percent(100.0),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            ..default()
+        })
+        .with_children(|parent| {
+            parent.spawn((
+                Node {
+                    width: Val::Px(200.0),
+                    border: UiRect::all(Val::Px(5.0)),
+                    padding: UiRect::all(Val::Px(5.0)),
+                    ..default()
+                },
+                BorderColor(BORDER_COLOR_ACTIVE),
+                BackgroundColor(BACKGROUND_COLOR),
+                TextInput,
+                TextInputSettings {
+                    character_limit: Some(12),
+                    ..default()
+                },
+                TextInputTextFont(TextFont {
+                    font_size: 34.,
+                    ..default()
+                }),
+                TextInputTextColor(TextColor(TEXT_COLOR)),
+            ));
+        });
+}
+
+fn listener(mut events: EventReader<TextInputSubmitEvent>) {
+    for event in events.read() {
+        info!("{:?} submitted: {}", event.entity, event.value);
+    }
+}

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -49,6 +49,7 @@ fn setup(mut commands: Commands) {
                 TextInputSettings {
                     mask_character: Some('*'),
                     retain_on_submit: true,
+                    ..default()
                 },
             ));
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@ fn keyboard(
             }
             if let Some(limit) = settings.character_limit {
                 if text_input.0.chars().count() >= limit as usize {
-                    limit_writer.write(TextInputLimitEvent {
+                    limit_writer.send(TextInputLimitEvent {
                         entity: input_entity,
                     });
                     continue;


### PR DESCRIPTION
These are the same changes as #103 but backported to version 0.10 to support Bevy 0.15.