### PR TITLE
Upgrade to Bevy 0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev
         if: runner.os == 'Linux'
       - name: check
         run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ std = ["bevy/std"]
 libm = ["bevy/libm"]
 
 [dependencies.bevy]
-version = "0.16.0"
+version = "0.17.0-rc.1"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 
 [dev-dependencies.bevy]
-version = "0.16.0"
+version = "0.17.0-rc.1"
 default-features = true
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ std = ["bevy/std"]
 libm = ["bevy/libm"]
 
 [dependencies.bevy]
-version = "0.17.0-rc.1"
+version = "0.17.0"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 
 [dev-dependencies.bevy]
-version = "0.17.0-rc.1"
+version = "0.17.0"
 default-features = true
 
 [lints.rust]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 use bevy_simple_text_input::{
-    TextInput, TextInputPlugin, TextInputSubmitEvent, TextInputSystem, TextInputTextColor,
+    TextInput, TextInputPlugin, TextInputSubmitMessage, TextInputSystem, TextInputTextColor,
     TextInputTextFont,
 };
 
@@ -38,7 +38,7 @@ fn setup(mut commands: Commands) {
                     padding: UiRect::all(Val::Px(5.0)),
                     ..default()
                 },
-                BorderColor(BORDER_COLOR_ACTIVE),
+                BorderColor::all(BORDER_COLOR_ACTIVE),
                 BackgroundColor(BACKGROUND_COLOR),
                 TextInput,
                 TextInputTextFont(TextFont {
@@ -50,7 +50,7 @@ fn setup(mut commands: Commands) {
         });
 }
 
-fn listener(mut events: EventReader<TextInputSubmitEvent>) {
+fn listener(mut events: MessageReader<TextInputSubmitMessage>) {
     for event in events.read() {
         info!("{:?} submitted: {}", event.entity, event.value);
     }

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -51,7 +51,7 @@ fn text_input() -> impl Bundle {
             padding: UiRect::all(Val::Px(5.0)),
             ..default()
         },
-        BorderColor(BORDER_COLOR_INACTIVE),
+        BorderColor::all(BORDER_COLOR_INACTIVE),
         BackgroundColor(BACKGROUND_COLOR),
         TextInput,
         TextInputTextFont(TextFont {
@@ -86,12 +86,12 @@ fn focus(
     }
 }
 
-fn background_node_click(mut trigger: Trigger<Pointer<Click>>, mut focus: ResMut<InputFocus>) {
+fn background_node_click(mut trigger: On<Pointer<Click>>, mut focus: ResMut<InputFocus>) {
     focus.0 = None;
     trigger.propagate(false);
 }
 
-fn text_input_click(mut trigger: Trigger<Pointer<Click>>, mut focus: ResMut<InputFocus>) {
-    focus.0 = Some(trigger.target());
+fn text_input_click(mut trigger: On<Pointer<Click>>, mut focus: ResMut<InputFocus>) {
+    focus.0 = Some(trigger.event_target());
     trigger.propagate(false);
 }

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -37,7 +37,7 @@ fn setup(mut commands: Commands) {
                     padding: UiRect::all(Val::Px(5.0)),
                     ..default()
                 },
-                BorderColor(BORDER_COLOR_ACTIVE),
+                BorderColor::all(BORDER_COLOR_ACTIVE),
                 BackgroundColor(BACKGROUND_COLOR),
                 TextInput,
                 TextInputValue("password".to_string()),

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -50,7 +50,7 @@ fn setup(mut commands: Commands) {
                     padding: UiRect::all(Val::Px(5.0)),
                     ..default()
                 },
-                BorderColor(BORDER_COLOR_ACTIVE),
+                BorderColor::all(BORDER_COLOR_ACTIVE),
                 BackgroundColor(BACKGROUND_COLOR),
                 TextInput,
                 TextInputTextFont(text_font.clone()),
@@ -72,7 +72,7 @@ fn setup(mut commands: Commands) {
                         justify_content: JustifyContent::Center,
                         ..default()
                     },
-                    BorderColor(BORDER_COLOR_INACTIVE),
+                    BorderColor::all(BORDER_COLOR_INACTIVE),
                     BackgroundColor(BACKGROUND_COLOR),
                     IncValueButton,
                 ))
@@ -110,13 +110,13 @@ fn button_style_system(
     for (interaction, mut border_color) in &mut interaction_query {
         match *interaction {
             Interaction::Pressed => {
-                border_color.0 = BORDER_COLOR_ACTIVE;
+                border_color.set_all(BORDER_COLOR_ACTIVE);
             }
             Interaction::Hovered => {
-                border_color.0 = BORDER_COLOR_HOVER;
+                border_color.set_all(BORDER_COLOR_HOVER);
             }
             Interaction::None => {
-                border_color.0 = BORDER_COLOR_INACTIVE;
+                border_color.set_all(BORDER_COLOR_INACTIVE);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!             border: UiRect::all(Val::Px(2.0)),
 //!             ..default()
 //!         },
-//!         BorderColor(Color::BLACK)
+//!         BorderColor::all(Color::BLACK)
 //!     ));
 //! }
 //! ```


### PR DESCRIPTION
Bevy 0.17 didn't land a text input, so `bevy_simple_text_input` lives to see another day!

There probably won't be a crates.io release until Bevy 0.17.0 is properly released, but you can use this git branch in the mean time.

```toml
[dependencies.bevy_simple_text_input]
git = "https://github.com/rparrett/bevy_simple_text_input.git"
branch = "bevy-0.17"
```