### PR TITLE
Update to Bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ std = ["bevy/std"]
 libm = ["bevy/libm"]
 
 [dependencies.bevy]
-version = "0.17.0"
+version = "0.18.0-rc.2"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 
 [dev-dependencies.bevy]
-version = "0.17.0"
+version = "0.18.0-rc.2"
 default-features = true
 
 [lints.rust]


### PR DESCRIPTION
Just a version bump. However, the zero-width cursor rendered as `{`. I'm not sure why.