### PR TITLE
Upgrade to Bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ std = ["bevy/std"]
 libm = ["bevy/libm"]
 
 [dependencies.bevy]
-version = "0.19.0-rc.1"
+version = "0.19.0"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 
 [dev-dependencies.bevy]
-version = "0.19.0-rc.1"
+version = "0.19.0"
 default-features = true
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ std = ["bevy/std"]
 libm = ["bevy/libm"]
 
 [dependencies.bevy]
-git = "https://github.com/bevyengine/bevy"
+version = "0.19.0-rc.1"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 
 [dev-dependencies.bevy]
-git = "https://github.com/bevyengine/bevy"
+version = "0.19.0-rc.1"
 default-features = true
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ std = ["bevy/std"]
 libm = ["bevy/libm"]
 
 [dependencies.bevy]
-version = "0.18.0"
+git = "https://github.com/bevyengine/bevy"
 default-features = false
 features = ["bevy_ui", "bevy_asset", "bevy_text", "bevy_window"]
 
 [dev-dependencies.bevy]
-version = "0.18.0"
+git = "https://github.com/bevyengine/bevy"
 default-features = true
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ An unambitious single-line text input widget for `bevy_ui`.
 
 ![animated screenshot of text input widget gaining focus and text typed and submitted](assets/screenshot.gif)
 
+## Deprecated
+
+Bevy 0.19 now has a built-in [EditableText](https://bevy.org/news/bevy-0-19/#text-input) component. It is better and has more features overall, and you should probably use it instead of this.
+
+I am not planning on any more non-bugfix releases and will archive the project when Bevy 0.20 is release.
+
 ## Usage
 
 > [!IMPORTANT]
@@ -68,7 +74,3 @@ Please feel free to open a PR!
 The code should be simple enough for users to quickly understand and modify for their own purposes. Any new dependencies must not also depend on Bevy. Ideally, we should not add *any* new dependencies.
 
 Please keep PRs small and scoped to a single feature or fix.
-
-## Alternatives
-
-If you need more features, check out [`bevy_ui_text_input`](https://github.com/ickshonpe/bevy_ui_text_input) or [`bevy_egui`](https://github.com/mvlabat/bevy_egui).

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -42,7 +42,7 @@ fn setup(mut commands: Commands) {
                 BackgroundColor(BACKGROUND_COLOR),
                 TextInput,
                 TextInputTextFont(TextFont {
-                    font_size: 34.,
+                    font_size: FontSize::Px(34.),
                     ..default()
                 }),
                 TextInputTextColor(TextColor(TEXT_COLOR)),

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -1,7 +1,7 @@
 //! An example showing a more advanced implementation with focus.
 
 use bevy::{
-    input_focus::{InputDispatchPlugin, InputFocus},
+    input_focus::{FocusCause, InputFocus},
     prelude::*,
 };
 use bevy_simple_text_input::{
@@ -16,7 +16,7 @@ const BACKGROUND_COLOR: Color = Color::srgb(0.15, 0.15, 0.15);
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, InputDispatchPlugin))
+        .add_plugins(DefaultPlugins)
         .add_plugins(TextInputPlugin)
         .add_systems(Startup, setup)
         .add_systems(Update, focus.before(TextInputSystem))
@@ -55,7 +55,7 @@ fn text_input(placeholder_hide_on_focus: bool) -> impl Bundle {
         BackgroundColor(BACKGROUND_COLOR),
         TextInput,
         TextInputTextFont(TextFont {
-            font_size: 34.,
+            font_size: FontSize::Px(34.),
             ..default()
         }),
         TextInputTextColor(TextColor(TEXT_COLOR)),
@@ -77,7 +77,7 @@ fn focus(
     }
 
     for (entity, mut inactive, mut border_color) in text_inputs.iter_mut() {
-        if focus.0 == Some(entity) {
+        if focus.get() == Some(entity) {
             inactive.0 = false;
             *border_color = BORDER_COLOR_ACTIVE.into();
         } else {
@@ -88,11 +88,11 @@ fn focus(
 }
 
 fn background_node_click(mut trigger: On<Pointer<Click>>, mut focus: ResMut<InputFocus>) {
-    focus.0 = None;
+    focus.clear();
     trigger.propagate(false);
 }
 
 fn text_input_click(mut trigger: On<Pointer<Click>>, mut focus: ResMut<InputFocus>) {
-    focus.0 = Some(trigger.event_target());
+    focus.set(trigger.event_target(), FocusCause::Pressed);
     trigger.propagate(false);
 }

--- a/examples/password.rs
+++ b/examples/password.rs
@@ -43,7 +43,7 @@ fn setup(mut commands: Commands) {
                 TextInput,
                 TextInputValue("password".to_string()),
                 TextInputTextFont(TextFont {
-                    font_size: 34.,
+                    font_size: FontSize::Px(34.),
                     ..default()
                 }),
                 TextInputTextColor(TextColor(TEXT_COLOR)),

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -28,7 +28,7 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
     let text_font = TextFont {
-        font_size: 40.,
+        font_size: FontSize::Px(40.),
         ..default()
     };
     let text_color = TextColor(TEXT_COLOR);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl Plugin for TextInputPlugin {
             app,
             CURSOR_HANDLE,
             "../assets/Cursor.ttf",
-            |bytes: &[u8], _path: String| { Font::from_bytes(bytes.to_vec(), "Cursor") }
+            |bytes: &[u8], _path: String| { Font::from_bytes(bytes.to_vec()) }
         );
 
         app.init_resource::<TextInputNavigationBindings>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,7 +618,7 @@ fn create(
         let text = commands
             .spawn((
                 Text::default(),
-                TextLayout::new_with_linebreak(LineBreak::NoWrap),
+                TextLayout::default().with_linebreak(LineBreak::NoWrap),
                 Name::new("TextInputInner"),
                 TextInputInner,
             ))
@@ -660,7 +660,7 @@ fn create(
         let placeholder_text = commands
             .spawn((
                 Text::default(),
-                TextLayout::new_with_linebreak(LineBreak::NoWrap),
+                TextLayout::default().with_linebreak(LineBreak::NoWrap),
                 Name::new("TextInputPlaceholderInner"),
                 TextInputPlaceholderInner,
                 if placeholder_visible {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl Plugin for TextInputPlugin {
             app,
             CURSOR_HANDLE,
             "../assets/Cursor.ttf",
-            |bytes: &[u8], _path: String| { Font::try_from_bytes(bytes.to_vec()).unwrap() }
+            |bytes: &[u8], _path: String| { Font::from_bytes(bytes.to_vec(), "Cursor") }
         );
 
         app.init_resource::<TextInputNavigationBindings>()
@@ -534,7 +534,7 @@ fn scroll_with_cursor(
             continue;
         };
 
-        match layout.glyphs.last().map(|g| g.span_index) {
+        match layout.glyphs.last().map(|g| g.section_index) {
             // No text, nothing to do.
             None => continue,
             // If cursor is at the end, we can use FlexEnd so newly typed text does not take a
@@ -555,7 +555,7 @@ fn scroll_with_cursor(
         let Some(cursor_pos) = layout
             .glyphs
             .iter()
-            .find(|g| g.span_index == CURSOR_SPAN)
+            .find(|g| g.section_index == CURSOR_SPAN)
             .map(|p| p.position.x * inverse_scale_factor)
         else {
             continue;
@@ -630,7 +630,7 @@ fn create(
                 parent.spawn((
                     TextSpan::new(&values.1),
                     TextFont {
-                        font: CURSOR_HANDLE,
+                        font: FontSource::Handle(CURSOR_HANDLE),
                         ..font.0.clone()
                     },
                     if inactive.0 {
@@ -678,7 +678,7 @@ fn create(
                 parent.spawn((
                     TextSpan::new(&values.1),
                     TextFont {
-                        font: CURSOR_HANDLE,
+                        font: FontSource::Handle(CURSOR_HANDLE),
                         ..font.0.clone()
                     },
                     TextColor(Color::NONE),
@@ -826,7 +826,7 @@ fn update_style(
 
         *writer.font(inner, PRE_CURSOR_SPAN) = font.0.clone();
         *writer.font(inner, CURSOR_SPAN) = TextFont {
-            font: CURSOR_HANDLE,
+            font: FontSource::Handle(CURSOR_HANDLE),
             ..font.0.clone()
         };
         *writer.font(inner, POST_CURSOR_SPAN) = font.0.clone();


### PR DESCRIPTION
Draft, as we don't even have a release candidate yet for 0.19 yet.

- [X] There seems to be a bug with scrolling back/forth through long values.
    This is an old bug.
    The change that broke it was #109.
    edit: Fixed with #117
- [X] Add a deprecation notice and ~~migration guide.~~
    Bevy 0.19 will include a text input that is way nicer than this one. When Bevy 0.20 is released, we won't be doing a release to support it and will archive the project at that time.